### PR TITLE
Mustache: support Windows

### DIFF
--- a/Sources/Mustache/MustacheParser.swift
+++ b/Sources/Mustache/MustacheParser.swift
@@ -212,6 +212,8 @@ public struct MustacheParser {
 
 #if os(Linux)
   import func Glibc.memcpy
+#elseif os(Windows)
+  import func ucrt.memcpy
 #else
   import func Darwin.memcpy
 #endif


### PR DESCRIPTION
This adds a Windows specific import for `memcpy` to allow building and using Mustache on Windows.